### PR TITLE
PPD-667 -> Make the wrapper can receive response from status code (202)

### DIFF
--- a/lib/midtrans_api/errors.rb
+++ b/lib/midtrans_api/errors.rb
@@ -4,8 +4,6 @@ module MidtransApi
   class Errors
     class ResponseError < StandardError; end
 
-    class PaymentDenied < ResponseError; end
-
     class MovePermanently < ResponseError; end
 
     class ValidationError < ResponseError; end

--- a/lib/midtrans_api/middleware/handle_response_exception.rb
+++ b/lib/midtrans_api/middleware/handle_response_exception.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
-
 module MidtransApi
   module Middleware
     class HandleResponseException < Faraday::Middleware
-      VALID_STATUSES = %w[200 201 407].freeze
+      VALID_STATUSES = %w[200 201 202 407].freeze
 
       def initialize(app)
         super(app)
@@ -20,11 +19,10 @@ module MidtransApi
       # rubocop:disable Metrics/CyclomaticComplexity
       def validate_response(response)
         json_response = JSON.parse(response)
+
         return true if VALID_STATUSES.include?(json_response['status_code'])
 
         case json_response['status_code']
-        when '202'
-          raise MidtransApi::Errors::PaymentDenied, json_response['status_message']
         when '300'
           raise MidtransApi::Errors::MovePermanently, json_response['status_message']
         when '400'

--- a/spec/lib/midtrans_api/errors_spec.rb
+++ b/spec/lib/midtrans_api/errors_spec.rb
@@ -30,17 +30,6 @@ RSpec.describe MidtransApi::Errors do
       end
     end
 
-    context 'status code 2xx' do
-      it 'PaymentDenied' do
-        dummy_response[:status_code] = '202'
-        stub_request(:get, "#{client.config.api_url}/#{client.config.api_version}/test")
-          .to_return(status: 200, body: dummy_response.to_json)
-        expect do
-          client.get("#{client.config.api_url}/#{client.config.api_version}/test", {})
-        end.to raise_error(MidtransApi::Errors::PaymentDenied, 'This is dummy status message of error code.')
-      end
-    end
-
     context 'status code 3xx' do
       it 'MovePermanently' do
         dummy_response[:status_code] = '300'


### PR DESCRIPTION
## Summary

Make the wrapper can receive API response from HTTP status_code 202.  We need to know the error message in credit card payment, and the error message only available inside the transaction status API (not in the callback).  

We can't receive all the response messages in the current condition because it's will throw an exception. 