### PR TITLE
Add logger

### DIFF
--- a/lib/midtrans_api.rb
+++ b/lib/midtrans_api.rb
@@ -3,6 +3,15 @@
 module MidtransApi
   API_PRODUCTION_URL = 'https://api.midtrans.com'
   API_SANDBOX_URL = 'https://api.sandbox.midtrans.com'
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= MidtransApi::Configure.new
+    yield(configuration)
+  end
 end
 
 require 'midtrans_api/errors'

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(%r{(#{filter}=)([\w+-.?\/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":")([\w+-.?\/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":)([\w+-.?\/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}=)([\w+-.?:/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":")([\w+-.?:/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":)([\w+-.?:/]+)}, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(/(#{filter}=)([\w-+:/.?]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":")([\w-+:/.?]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":)([\w-+:/.?]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)([\w-+.?\/]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":")([\w-+.?\/]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":)([\w-+.?\/]+)/, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(%r{(#{filter}=)([\w+-.?:/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":")([\w+-.?:/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":)([\w+-.?:/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}=)([\w+-.?@:/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":")([\w+-.?@:/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":)([\w+-.?@:/]+)}, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,8 +44,8 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(/(#{filter}=)([\w-]+)/, '\1[FILTERED]')
                 log.filter(/(#{filter}=)(#{URI::DEFAULT_PARSER.make_regexp})/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)([\w-]+)/, '\1[FILTERED]')
                 log.filter(/(#{filter}":")([\w-]+)/, '\1[FILTERED]')
                 log.filter(/(#{filter}":)([\w-]+)/, '\1[FILTERED]')
               end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -39,6 +39,7 @@ module MidtransApi
         connection.use MidtransApi::Middleware::HandleResponseException
         connection.adapter Faraday.default_adapter
 
+        logger = find_logger(options[:logger])
         if logger
           connection.response :logger, logger, { headers: false, bodies: true } do |log|
             filtered_logs = options[:filtered_logs]
@@ -82,8 +83,8 @@ module MidtransApi
 
     private
 
-    def logger
-      MidtransApi.configuration&.logger
+    def find_logger(logger_options)
+      logger_options || MidtransApi.configuration&.logger
     end
   end
 end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -27,7 +27,7 @@ module MidtransApi
       yield @config if block_given?
 
       @connection = Faraday.new(url: "#{@config.api_url}/#{@config.api_version}/") do |connection|
-        connection.basic_auth(@config.server_key, '')
+        connection.request :basic_auth, @config.server_key, ''
 
         unless @config.notification_url.nil?
           connection.headers['X-Override-Notification'] = @config.notification_url

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -45,9 +45,9 @@ module MidtransApi
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
                 log.filter(/(#{filter}=)(#{URI::DEFAULT_PARSER.make_regexp})/, '\1[FILTERED]')
-                log.filter(/(#{filter}=)([\w-]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":")([\w-]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":)([\w-]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)([\w-+]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":")([\w-+]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":)([\w-+]+)/, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,10 +44,10 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(/(#{filter}=)(\w+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)([\w-]+)/, '\1[FILTERED]')
                 log.filter(/(#{filter}=)(#{URI::DEFAULT_PARSER.make_regexp})/, '\1[FILTERED]')
-                log.filter(/(#{filter}":")(\w+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":)(\w+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":")([\w-]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":)([\w-]+)/, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(/(#{filter}=)([\w-+.?\/]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":")([\w-+.?\/]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":)([\w-+.?\/]+)/, '\1[FILTERED]')
+                log.filter(%r{(#{filter}=)([\w-+.?/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":")([\w-+.?/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":)([\w-+.?/]+)}, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,10 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(/(#{filter}=)(#{URI::DEFAULT_PARSER.make_regexp})/, '\1[FILTERED]')
-                log.filter(/(#{filter}=)([\w-+]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":")([\w-+]+)/, '\1[FILTERED]')
-                log.filter(/(#{filter}":)([\w-+]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)([\w-+:/.?]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":")([\w-+:/.?]+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}":)([\w-+:/.?]+)/, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                # filter when data type was string
+                log.filter(/(#{filter}=)(\w+)/, '\1[FILTERED]')
+                log.filter(/(#{filter}=)(#{URI::DEFAULT_PARSER.make_regexp})/, '\1[FILTERED]')
                 log.filter(/(#{filter}":")(\w+)/, '\1[FILTERED]')
-                # filter when data type wasnt string (maybe number, boolean, etc)
                 log.filter(/(#{filter}":)(\w+)/, '\1[FILTERED]')
               end
             end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -44,9 +44,9 @@ module MidtransApi
             filtered_logs = options[:filtered_logs]
             if filtered_logs.respond_to?(:each)
               filtered_logs.each do |filter|
-                log.filter(%r{(#{filter}=)([\w-+.?/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":")([\w-+.?/]+)}, '\1[FILTERED]')
-                log.filter(%r{(#{filter}":)([\w-+.?/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}=)([\w+-.?\/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":")([\w+-.?\/]+)}, '\1[FILTERED]')
+                log.filter(%r{(#{filter}":)([\w+-.?\/]+)}, '\1[FILTERED]')
               end
             end
           end

--- a/lib/midtrans_api/configure.rb
+++ b/lib/midtrans_api/configure.rb
@@ -5,7 +5,8 @@ module MidtransApi
     attr_accessor :client_key,
                   :server_key,
                   :notification_url,
-                  :sandbox_mode
+                  :sandbox_mode,
+                  :logger
     attr_reader   :api_version
 
     def initialize(options = {})

--- a/spec/lib/midtrans_api_spec.rb
+++ b/spec/lib/midtrans_api_spec.rb
@@ -7,4 +7,21 @@ describe MidtransApi do
     expect(MidtransApi::API_PRODUCTION_URL).not_to be nil
     expect(MidtransApi::API_SANDBOX_URL).not_to be nil
   end
+
+  describe '#configure' do
+    after do
+      # clening up cache test data
+      described_class.configure do |config|
+        config.logger = nil
+      end
+    end
+
+    it 'returns expected custom logger' do
+      custom_logger = Class.new(Object)
+      described_class.configure do |config|
+        config.logger = custom_logger
+      end
+      expect(described_class.configuration.logger).to eq custom_logger
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add logger and customizable setup to the logger.

### Install

You can enable the logger like this (we assume you're using Rails)

```rb
# config/initializers/midtrans_api.rb

require 'midtrans_api'

MidtransApi.configure do |config|
  config.logger = Rails.logger
end
```

Done. Now we will log every request. 

### Filter logs
But we don't filter logs by default, and make sure you log every sensitive information, like card number, cvv, etc.

To filter logs, you can do when initializing the client

```rb
midtrans = MidtransApi::Client.new(client_key: 'secret', secret_key: 'secret', sandbox: false, filtered_logs: %i[card_cvv card_number])
```

```
