### PR TITLE
KRED-474: add expire transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ bca_virtual_account_charge = midtrans.bca_virtual_account_charge.post(charge_par
 #=> bca_virtual_account_charge returns MidtransApiMidtransApi::Model::BcaVirtualAccount::Charge instance
 ```
 
+#### Expire Transaction
+```ruby
+expire_response = midtrans.expire_transaction.post(order_id: "eb046679-285a-4136-8977-e4c429cc3254")
+#=> expire_response returns MidtransApiMidtransApi::Model::Transaction::Expire instance
+```
+
+
 #### Check Status Payment
 ```ruby
 dummy_order_id = "order-with-gopay"

--- a/lib/midtrans_api/api/transaction/expire.rb
+++ b/lib/midtrans_api/api/transaction/expire.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module MidtransApi
+  module Api
+    module Transaction
+      class Expire < MidtransApi::Api::Base
+
+        def post(order_id:)
+          response = client.post("#{order_id}/expire",{})
+
+          MidtransApi::Model::Transaction::Expire.new(response)
+        end
+      end
+    end
+  end
+end

--- a/lib/midtrans_api/client.rb
+++ b/lib/midtrans_api/client.rb
@@ -9,6 +9,7 @@ require 'midtrans_api/api/bca_virtual_account/charge'
 require 'midtrans_api/api/credit_card/charge'
 require 'midtrans_api/api/credit_card/token'
 require 'midtrans_api/api/gopay/charge'
+require 'midtrans_api/api/transaction/expire'
 
 require 'midtrans_api/middleware/handle_response_exception'
 
@@ -18,6 +19,7 @@ require 'midtrans_api/model/bca_virtual_account/charge'
 require 'midtrans_api/model/credit_card/charge'
 require 'midtrans_api/model/credit_card/token'
 require 'midtrans_api/model/gopay/charge'
+require 'midtrans_api/model/transaction/expire'
 
 module MidtransApi
   class Client
@@ -59,6 +61,10 @@ module MidtransApi
 
     def bca_virtual_account_charge
       @charge ||= MidtransApi::Api::BcaVirtualAccount::Charge.new(self)
+    end
+
+    def expire_transaction
+      @expire ||= MidtransApi::Api::Transaction::Expire.new(self)
     end
 
     def gopay_charge

--- a/lib/midtrans_api/model/transaction/expire.rb
+++ b/lib/midtrans_api/model/transaction/expire.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module MidtransApi
+  module Model
+    module Transaction
+      class Expire < MidtransApi::Model::Base
+        resource_attributes :gross_amount,
+                            :order_id,
+                            :payment_type,
+                            :status_code,
+                            :status_message,
+                            :transaction_id,
+                            :transaction_status,
+                            :transaction_time
+
+        def resolve_params_attr(attr)
+          attr.to_s
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/midtrans_api/api/transaction/expire_spec.rb
+++ b/spec/lib/midtrans_api/api/transaction/expire_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MidtransApi::Api::Transaction::Expire do
+  let(:client) do
+    MidtransApi::Client.new(
+      client_key: 'client_key',
+      server_key: 'server_key',
+      sandbox: true,
+      notification_url: 'someapps://callback'
+    )
+  end
+
+  describe '#post' do
+    context 'with valid params' do
+      dummy_response = {
+        "status_code": "407",
+        "status_message": "Success, transaction is expired",
+        "transaction_id": "24dd3e24-2b1f-4e09-9176-f4a15df3c869",
+        "order_id": "eb046679-285a-4136-8977-e4c429cc3254",
+        "merchant_id": "M045108",
+        "gross_amount": "1000000.00",
+        "currency": "IDR",
+        "payment_type": "bank_transfer",
+        "transaction_time": "2023-03-15 15:19:23",
+        "transaction_status": "expire",
+        "fraud_status": "accept"
+      }
+      dummy_order_id = "eb046679-285a-4136-8977-e4c429cc3254"
+      it 'using described class returns success response' do
+        stub_request(:post, "#{client.config.api_url}/#{client.config.api_version}/#{dummy_order_id}/expire")
+          .with(body: {})
+          .to_return(status: 200, body: dummy_response.to_json)
+        expire_api = described_class.new(client)
+        response = expire_api.post(order_id: dummy_order_id)
+
+        expect(response).to be_instance_of MidtransApi::Model::Transaction::Expire
+        expect(response.order_id).to eq dummy_order_id
+        expect(response.transaction_status).to eq "expire"
+      end
+    end
+
+    context 'with invalid params' do
+      it 'raise NotFound; invalid transaction_id' do
+        dummy_response = {
+          "status_code": '404',
+          "status_message": 'Transaction doesn\'t exist.',
+          "id": 'b19510c2-6ad3-4c5b-92bf-049cfd5846c9'
+        }
+        dummy_order_id = "eb046679-28512312323254"
+        stub_request(:post, "#{client.config.api_url}/#{client.config.api_version}/#{dummy_order_id}/expire")
+          .with(body: {})
+          .to_return(status: 200, body: dummy_response.to_json)
+        expect do
+          expire_api = described_class.new(client)
+          expire_api.post(order_id: dummy_order_id)
+        end.to raise_error(MidtransApi::Errors::NotFound, 'Transaction doesn\'t exist.')
+      end
+
+      it 'raise CannotModifyTransaction; cannot modify transaction' do
+        dummy_response = {
+          "status_code": '412',
+          "status_message": 'Transaction status cannot be updated.',
+          "id": '95c25db5-08a4-4b3e-b7ce-8d56ebed1dac'
+        }
+        dummy_order_id = "2d44562e-6cb6-44f5-8cbd-751acb6e9cd2"
+        stub_request(:post, "#{client.config.api_url}/#{client.config.api_version}/#{dummy_order_id}/expire")
+          .with(body: {})
+          .to_return(status: 200, body: dummy_response.to_json)
+        expect do
+          expire_api = described_class.new(client)
+          expire_api.post(order_id: dummy_order_id)
+        end.to raise_error(MidtransApi::Errors::CannotModifyTransaction, 'Transaction status cannot be updated.')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add new feature expire transaction: 
When expired transaction is called, the user cannot pay the invoice/va with specific order_id

example code:
midtrans_api.expire_transaction.post(order_id: "eb046679-285a-4136-8977-e4c429cc3254")